### PR TITLE
Change terryma/vim-multiple-cursors

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -157,7 +157,7 @@ if count(g:ivim_bundle_groups, 'enhance') " Vim enhancement
     NeoBundle 'tpope/vim-abolish' " Abolish
     NeoBundle 'tpope/vim-speeddating' " Speed dating
     NeoBundle 'tpope/vim-repeat' " Repeat
-    NeoBundle 'terryma/vim-multiple-cursors' " Multiple cursors
+    NeoBundle 'kristijanhusak/vim-multiple-cursors' " Multiple cursors
     NeoBundle 'mbbill/undotree' " Undo tree
     NeoBundle 'tpope/vim-surround' " Surround
     NeoBundle 'godlygeek/tabular' " Tabular


### PR DESCRIPTION
Change terryma/vim-multiple-cursors to kristijanhusak/vim-multiple-cursors.

Vim-multiple-cursors conflicts with neocomplete, sometimes I got lots of <PLUG> tags when I was using vim-multiple-cursors.
And I find this from google:
https://github.com/joedicastro/dotfiles/issues/12
and
https://github.com/terryma/vim-multiple-cursors/issues/51
So, I change terryma to kristijanhusak. Now, vim-multiple-cursors works fine.
