### PR TITLE
fix bug: E739: Cannot create directory: foo/bar/

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -93,7 +93,8 @@ function! InitializeDirectories()
         let directory=parent.'/'.prefix.'/'.dirname.'/'
         if !isdirectory(directory)
             if exists('*mkdir')
-                call mkdir(directory, 'p')
+                let dir = substitute(directory, "/$", "", "")
+                call mkdir(dir, 'p')
             else
                 echo 'Warning: Unable to create directory: '.directory
             endif


### PR DESCRIPTION
Everytime I removed .vim/view folder, and run vim again, I got error: Cannot create directory, but the directory was created actually.
I got some message from google groups:
https://groups.google.com/forum/#!topic/vim_dev/rFT67RzKMfU
E739: Cannot create directory: foo/bar/, but the directory was created just fine.
Dropping the trailing slash works without error:
  :call mkdir('foo/bar', 'p')
That is a bug: When using 'p' parameter, and the dir has one trailing slash, mkdir will give this error message. So I cut off the trailling slash, now mkdir works fine.
